### PR TITLE
Avoid unnecessary `StateSet`s when new state is equal to existing value

### DIFF
--- a/counterweight/hooks/hooks.py
+++ b/counterweight/hooks/hooks.py
@@ -28,6 +28,8 @@ def use_state(initial_value: Getter[T] | T) -> tuple[T, Setter[T]]:
         A function that can be called to update the value of the state (e.g., in an event handler).
             It can either be called with the new value of the state,
             or a function that takes the current value of the state and returns the new value of the state.
+            If the value is not equal to the current of the state,
+            Counterweight will trigger a render cycle.
     """
     return current_hook_state.get().use_state(initial_value)
 

--- a/counterweight/hooks/impls.py
+++ b/counterweight/hooks/impls.py
@@ -58,8 +58,10 @@ class Hooks(ForbidExtras):
         def set_state(value: T | Callable[[T], T]) -> None:
             if callable(value):
                 value = value(hook.value)  # type: ignore[arg-type]
-            hook.value = value
-            current_event_queue.get().put_nowait(StateSet())
+
+            if hook.value != value:  # avoid unnecessary updates
+                hook.value = value
+                current_event_queue.get().put_nowait(StateSet())
 
         current_hook_idx.set(current_hook_idx.get() + 1)
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -2,6 +2,12 @@
 
 ## Next
 
+## Changed
+
+- [#110](https://github.com/JoshKarpel/counterweight/pull/110)
+  Calling a `use_state` setter with a `value` equal to the current value of the state
+  no longer emits a `SetState` event, to avoid triggering unnecessary render cycles.
+
 ## `0.0.7`
 
 Released `2024-02-02`


### PR DESCRIPTION
<!--- Provide a general summary of your changes here. -->

Tasks
-----

- [x] Updated changelog.
- [x] Updated documentation.
